### PR TITLE
Wrapping long branch names

### DIFF
--- a/widgets/circle_ci/circle_ci.scss
+++ b/widgets/circle_ci/circle_ci.scss
@@ -21,6 +21,12 @@ $moreinfo-color:    rgba(255, 255, 255, 0.7);
     opacity: 0.05;
   }
 
+  .commit-body {
+    word-break: break-word;
+    overflow-y: scroll;
+    height: 80px;
+  }
+
   .committer-info {
     margin: 10px 0px;
     padding: 5px;


### PR DESCRIPTION
Previously they would stretch the square into a rectangle which would be half hidden by an adjacent square.
Now it wraps and there is a scroll bar that appears if its more than 3 lines long.